### PR TITLE
Remove headers forbidden by undici before proxying request

### DIFF
--- a/src/proxy/utils.ts
+++ b/src/proxy/utils.ts
@@ -18,12 +18,18 @@ export const prepareHeaders = (
 	host: string,
 	originalHeaders: IncomingHttpHeaders,
 	remoteAddress?: string
-): IncomingHttpHeaders => ({
-	...originalHeaders,
-	'x-forwarded-for': originalHeaders['x-forwarded-for'] ?? remoteAddress,
-	'x-forwarded-host': host,
-	host,
-})
+): IncomingHttpHeaders => {
+	// filter out forbidden client headers
+	const filteredHeaders = {
+		...originalHeaders,
+		'x-forwarded-for': originalHeaders['x-forwarded-for'] ?? remoteAddress,
+		'x-forwarded-host': host,
+		host,
+	}
+	delete filteredHeaders.connection
+	delete filteredHeaders.upgrade
+	return filteredHeaders
+}
 
 export const pipeResponse = async (
 	routeTargetHost: string,


### PR DESCRIPTION
Currently, the smartlook-relay-proxy crashes if the proxied request from the browser contains any of the following headers `Connection` or `Upgrade`. This is because headers are passed directly to `undici`, which will deliberately crash because those headers should not be set manually by the user. The `Upgrade` header is set e.g. for HTTP/2 requests.

The following example crashes the proxy after using: `curl http://localhost:1234/recorder.js --http2`

```
$ docker run --name="smartlook-relay-proxy" --rm -it  -p 1234:8000 smartlook/relay-proxy:3.1
{"level":30,"time":1661771175377,"pid":1,"hostname":"dc828e56375e","msg":"Starting proxy..."}
{"level":30,"time":1661771175381,"pid":1,"hostname":"dc828e56375e","msg":"Proxy started on port 8000"}
/home/node/app/node_modules/undici/lib/core/request.js:284
    throw new InvalidArgumentError('invalid connection header')
          ^

InvalidArgumentError: invalid connection header
    at processHeader (/home/node/app/node_modules/undici/lib/core/request.js:284:11)
    at new Request (/home/node/app/node_modules/undici/lib/core/request.js:132:9)
    at Client.[dispatch] (/home/node/app/node_modules/undici/lib/client.js:264:21)
    at Client.dispatch (/home/node/app/node_modules/undici/lib/dispatcher-base.js:146:29)
    at Pool.[dispatch] (/home/node/app/node_modules/undici/lib/pool-base.js:143:28)
    at Pool.dispatch (/home/node/app/node_modules/undici/lib/dispatcher-base.js:146:29)
    at Agent.[dispatch] (/home/node/app/node_modules/undici/lib/agent.js:117:23)
    at Agent.dispatch (/home/node/app/node_modules/undici/lib/dispatcher-base.js:146:29)
    at Agent.stream (/home/node/app/node_modules/undici/lib/api/api-stream.js:185:10)
    at /home/node/app/node_modules/undici/lib/api/api-stream.js:178:14 {
  code: 'UND_ERR_INVALID_ARG'
}
```

A similar crash happens if the proxy is located behind a GCP Load balancer, because the load balancer sets the `Connection` header.

Suggestion: filter out the problematic headers so they aren't proxied.