### PR TITLE
Add proxy_ssl_server_name to enable SNI

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -7,6 +7,7 @@ server {
     listen ${PROXY_PORT};
     
     proxy_cache off;
+    proxy_ssl_server_name on;
 
     server_tokens off;
     client_max_body_size ${CLIENT_MAX_BODY_SIZE};


### PR DESCRIPTION
Since at least Jun 20th, connections to web-sdk.smartlook.com were failing with

```
nginx  | 2024/07/01 13:40:58 [error] 41#41: *13 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::sslv3 alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.20:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [warn] 41#41: *13 upstream server temporarily disabled while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.20:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [error] 41#41: *13 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::sslv3 alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.87:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [warn] 41#41: *13 upstream server temporarily disabled while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.87:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [error] 41#41: *13 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::sslv3 alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.128:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [warn] 41#41: *13 upstream server temporarily disabled while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.128:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [error] 41#41: *13 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::sslv3 alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.91:443/recorder.js", host: "127.0.0.1"
nginx  | 2024/07/01 13:40:58 [warn] 41#41: *13 upstream server temporarily disabled while SSL handshaking to upstream, client: 172.27.1.1, server: , request: "GET /recorder.js HTTP/1.1", upstream: "https://13.32.110.91:443/recorder.js", host: "127.0.0.1"
nginx  | 172.27.1.1 - - [01/Jul/2024:13:40:58 +0000] "GET /recorder.js HTTP/1.1" 502 150 "-" "curl/8.8.0"
```

Based on https://stackoverflow.com/a/38401715/4918 I could verify locally that this fixes the issue for me.